### PR TITLE
Fix to work with newer Net::SIP (0.812)

### DIFF
--- a/lib/Net/SIP/Dispatcher/AnyEvent.pm
+++ b/lib/Net/SIP/Dispatcher/AnyEvent.pm
@@ -33,11 +33,11 @@ sub new {
 
 sub addFD {
     my $self = shift;
-    my ( $fh, $cb_data, $name ) = @_;
+    my ( $fh, $rw, $cb_data, $name ) = @_;
 
     my $fn = fileno $fh or return;
 
-    $self->{'_fd_watchers'}{$fn} = AE::io $fh, 0, sub {
+    $self->{'_fd_watchers'}{$fn} = AE::io $fh, $rw, sub {
         invoke_callback( $cb_data, $fh );
     }
 }

--- a/lib/Net/SIP/Dispatcher/AnyEvent.pm
+++ b/lib/Net/SIP/Dispatcher/AnyEvent.pm
@@ -37,7 +37,7 @@ sub addFD {
 
     my $fn = fileno $fh or return;
 
-    $self->{'_fd_watchers'}{$fn} = AE::io $fh, $rw, sub {
+    $self->{'_fd_watchers'}{$fn}[$rw] = AE::io $fh, $rw, sub {
         invoke_callback( $cb_data, $fh );
     }
 }


### PR DESCRIPTION
A while ago Net::SIP added an extra parameter to addFD to specify read/write.
This change adds this parameter into the our addFD method and passes it on to AnyEvent

Before this change all tests timed out as the callback never fired when data arrived.

With this change some tests pass and some fail. None time out. The failed tests are likely due to other changes in Net::SIP that affect the tests and not the module itself.